### PR TITLE
Creado workflow que crea una issue si se detecta un autor o email de commit que no está en el .mailmap

### DIFF
--- a/.github/workflows/create_issue_if_author_is_not_found.yml
+++ b/.github/workflows/create_issue_if_author_is_not_found.yml
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const issueTitle = `Autor de commit no contemplado en .mailmap: ${process.env.AUTHOR_NAME} o ${process.env.AUTHOR_EMAIL}`;
-            const issueBody = `Un commit fue creado por un autor (o por un correo) que no está en el archivo .mailmap:\n\n- **Nombre**: ${process.env.AUTHOR_NAME}\n- **Email**: ${process.env.AUTHOR_EMAIL}\n\n. El archivo .mailmap sirve para trazar todos los nombres de usuario y de correo que utilizamos a solo un nombre de usuario y correo. Por este motivo, por favor actualiza el archivo .mailmap para introducir este autor.`;
+            const issueBody = `Un commit fue creado por un autor (o por un correo) que no está en el archivo .mailmap:\n\n- **Nombre**: ${process.env.AUTHOR_NAME}\n- **Email**: ${process.env.AUTHOR_EMAIL}\n\nEl archivo .mailmap sirve para trazar todos los nombres de usuario y de correo que utilizamos a solo un nombre de usuario y correo. Por este motivo, por favor actualiza el archivo .mailmap para introducir este autor.`;
             const label= ["bug"]
             
             await github.rest.issues.create({

--- a/.github/workflows/create_issue_if_author_is_not_found.yml
+++ b/.github/workflows/create_issue_if_author_is_not_found.yml
@@ -1,0 +1,50 @@
+name: Create issue if author is not found in .mailmap
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-author-in-mailmap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Obtener el autor y el email del commit
+        run: |
+          AUTHOR_NAME=$(git log -1 --pretty=format:'%an')
+          AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
+          echo "AUTHOR_NAME=${AUTHOR_NAME}" >> $GITHUB_ENV
+          echo "AUTHOR_EMAIL=${AUTHOR_EMAIL}" >> $GITHUB_ENV
+
+      - name: Comprobar si el autor esta en .mailmap
+        id: check_author
+        run: |
+          if ! grep -qE "$AUTHOR_NAME" .mailmap || ! grep -qE "$AUTHOR_EMAIL" .mailmap; then
+            echo "Autor no encontrado en .mailmap"
+            echo "author_not_found=true" >> $GITHUB_ENV
+          else
+            echo "Autor encontrado .mailmap"
+            echo "author_not_found=false" >> $GITHUB_ENV
+          fi
+
+      - name: Crear issue
+        if: env.author_not_found == 'true'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueTitle = `Autor de commit no contemplado en .mailmap: ${process.env.AUTHOR_NAME} o ${process.env.AUTHOR_EMAIL}`;
+            const issueBody = `Un commit fue creado por un autor (o por un correo) que no está en el archivo .mailmap:\n\n- **Nombre**: ${process.env.AUTHOR_NAME}\n- **Email**: ${process.env.AUTHOR_EMAIL}\n\n. El archivo .mailmap sirve para trazar todos los nombres de usuario y de correo que utilizamos a solo un nombre de usuario y correo. Por este motivo, por favor actualiza el archivo .mailmap para introducir este autor.`;
+            const label= ["bug"]
+            
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: issueTitle,
+              body: issueBody,
+              labels: label,
+            });


### PR DESCRIPTION
**Descripción clara del cambio**
Se ha creado creado un workflow que crea una issue si se detecta un autor o email de commit que no está en el .mailmap

**Motivación del cambio**
En el archivo .mailmap deben de estar todos los nombres y emails de autor que utilizamos durante el proyecto para que así se pueda trazar cada miembro del proyecto con los commits que se hacen. Entonces, se ha creado el archivo .mailmap en el proyecto y se han registrado todos los nombres de autor y correos que se han ido utilizando a lo largo del proyecto. Sin embargo, para automatizar este proceso de recogida de autores de commits, se debe crear un workflow que cree una issue si se detecta un autor o email en un commit pusheado a main que no está en el .mailmap. Issue relacionada #172 

**Impacto del cambio**
Se ha creado un nuevo workflow que crea issues. 

**Evidencia de pruebas**
Se ha probado en el repositorio personal.
