### PR TITLE
 Añadido setup para monitorización con Grafana y Prometheus

### DIFF
--- a/vagrant/07_monitoring.yml
+++ b/vagrant/07_monitoring.yml
@@ -1,0 +1,61 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Add Grafana GPG key
+      shell: |
+        curl -fsSL https://packages.grafana.com/gpg.key | gpg --dearmor -o /usr/share/keyrings/grafana-archive-keyring.gpg
+      args:
+        executable: /bin/bash
+
+    - name: Add Grafana repository
+      copy:
+        content: |
+          deb [signed-by=/usr/share/keyrings/grafana-archive-keyring.gpg] https://packages.grafana.com/oss/deb stable main
+        dest: /etc/apt/sources.list.d/grafana.list
+
+    - name: Update APT cache
+      apt:
+        update_cache: yes
+
+    - name: Install required packages
+      apt:
+        name:
+          - prometheus
+          - grafana
+        state: present
+
+    - name: Start and enable Prometheus service
+      systemd:
+        name: prometheus
+        state: started
+        enabled: yes
+
+    - name: Start and enable Grafana service
+      systemd:
+        name: grafana-server
+        state: started
+        enabled: yes
+
+    - name: Configure Prometheus to scrape basic node metrics
+      template:
+        src: prometheus.yml.j2
+        dest: /etc/prometheus/prometheus.yml
+      notify: Restart Prometheus
+
+    - name: Install Node Exporter
+      apt:
+        name: prometheus-node-exporter
+        state: present
+
+    - name: Ensure Node Exporter is running
+      systemd:
+        name: prometheus-node-exporter
+        state: started
+        enabled: yes
+
+  handlers:
+    - name: Restart Prometheus
+      systemd:
+        name: prometheus
+        state: restarted

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -40,6 +40,9 @@ Vagrant.configure("2") do |config|
   # Network configuration
   config.vm.network "forwarded_port", guest: 5000, host: 5000
   config.vm.network "forwarded_port", guest: 8089, host: 8089
+  config.vm.network "forwarded_port", guest: 9090, host: 9090 # Prometheus
+  config.vm.network "forwarded_port", guest: 3000, host: 3000 # Grafana
+  config.vm.network "forwarded_port", guest: 9100, host: 9100 # Node Exporter
 
   # Synced folders
   config.vm.synced_folder "../", "/vagrant"

--- a/vagrant/templates/prometheus.yml.j2
+++ b/vagrant/templates/prometheus.yml.j2
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['localhost:9100']


### PR DESCRIPTION
# **Descripción de la Pull Request (PR)**

Se ha añadido un nuevo playbook de Ansible con el objetivo de implementar herramientas de monitorización para la máquina virtual (MV) desplegada. Esto permite la visualización desde la máquina host de métricas avanzadas, como el porcentaje de uso de CPU, entre otras.

---

## **Herramientas Implementadas**

- **Prometheus**: Para la recolección y almacenamiento de métricas del sistema.
- **Grafana**: Para la visualización y creación de dashboards interactivos.
- **Node Exporter**: Para exponer métricas del sistema operativo, utilizadas por Prometheus.

---

## **Funcionamiento**

Sigue la guía de instalación de UVLHub pero añade el flag de provision para asegurar que el nuevo playbook se ejecuta.

```bash
vagrant up --provision
```

Una vez desplegada la MV, se expondrán tres nuevos puertos, cada uno destinado a un servicio específico:

```ruby
config.vm.network "forwarded_port", guest: 9090, host: 9090 # Prometheus
config.vm.network "forwarded_port", guest: 3000, host: 3000 # Grafana
config.vm.network "forwarded_port", guest: 9100, host: 9100 # Node Exporter
```

### **Validación del Estado de Prometheus**

Podemos comprobar que Prometheus está recolectando métricas correctamente accediendo a la URL:

**[http://localhost:9090/classic/targets](http://localhost:9090/classic/targets)**

Deberíamos observar una página similar a la siguiente captura, donde `localhost:9100` aparece como **UP**:

![Captura desde 2024-12-08 16-43-01](https://github.com/user-attachments/assets/8b7beae2-ecb9-4e23-8ca5-9e23fe592f7e)

---

### **Configuración de Grafana**

1. **Acceder a Grafana**: Visita **[http://localhost:3000](http://localhost:3000)**.
2. **Añadir un Data Source**:
   - En Grafana, crea un nuevo "Data Source" y selecciona Prometheus.
   - Configura la URL del endpoint de Prometheus: `http://localhost:9090`.
3. **Crear un Dashboard**:
   - Utiliza las métricas recolectadas por Node Exporter para crear paneles de visualización.
   - Por ejemplo, puedes usar una consulta específica para el porcentaje de uso de CPU.

---

### **Ejemplo de Métrica Visualizada**

En este caso, se ha creado un dashboard en Grafana que muestra el porcentaje de uso de CPU utilizando la siguiente query en PromQL:

```promql
100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
```


### **El Dashboard**

El dashboard muestra algo similar a esta captura:

![Captura desde 2024-12-08 17-14-59](https://github.com/user-attachments/assets/f24917f3-fe58-43a6-82dc-760670c223c4)

---

### **Impacto y Utilidad**

- **Permite monitorizar el rendimiento de la MV** y obtener datos en tiempo real sobre su estado.
- **Facilita la detección y resolución de problemas** mediante análisis visual.
- **Proporciona una solución automatizada y reproducible** para el monitoreo, completamente integrada en el flujo de despliegue con Vagrant y Ansible.

