### PR TITLE
Feat: modificacion del workflow de dockerhub para raspberry

### DIFF
--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -27,11 +27,20 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349
+        # uses: docker/setup-buildx-action@v2
+
 
       - name: Build and push Docker image
         run: |
           docker build -f docker/images/Dockerfile.dev -t uvlhubtortilla/tortilla-hub:latest .
           docker push uvlhubtortilla/tortilla-hub:latest
 
-      - name: Set up and deploy containers
-        run: docker compose -f docker/docker-compose.dev.yml up -d
+      # - name: Set up and deploy containers
+      #   run: docker compose -f docker/docker-compose.dev.yml up -d
+      - name: Deploy to Raspberry Pi
+        run: |
+          ssh -o StrictHostKeyChecking=no ${{ secrets.PI_USER }}@${{ secrets.PI_HOST }} << 'EOF'
+            docker pull uvlhubtortilla/tortilla-hub:latest
+            cd /developer/tortilla-hub
+            docker compose -f docker/docker-compose.dev.yml up -d --force-recreate
+          EOF


### PR DESCRIPTION
**Descripción del cambio:**
Se ha modificado el flujo de trabajo (workflow) ya existente que creaba una imagen del proyecto en docker cada vez que se hacía push a develop para que se corra un contenedor en una raspberry pi con el proyecto.

**Motivación:** 
El objetivo principal es tener una versión desplegada en un contenedor del proyecto en desarrollo siempre accesible desde cualquier dispositivo, para complementar al despliegue de la aplicación en producción alojada en Render.

**Impacto:**
 Este cambio mejora el flujo de trabajo y permite una vista previa constante del desarrollo.

**Instrucciones:**
Antes de aceptar la pull request, se debe completar la configuración en dispositivo raspberry para liberar la ip y que pueda ser accesible de forma pública. 