### PR TITLE
test: Añadir pruebas de selenium para la subida desde zip

### DIFF
--- a/app/modules/dataset/templates/dataset/view_dataset.html
+++ b/app/modules/dataset/templates/dataset/view_dataset.html
@@ -256,11 +256,13 @@
                 Download all ({{ dataset.get_file_total_size_for_human() }})
             </a>
             
-            <!-- Botón visible -->
-            <a href="#" id="uploadButton" class="btn btn-primary mt-3" style="border-radius: 5px;">
-                <i data-feather="upload" class="center-button-icon"></i>
-                Upload from ZIP
-            </a>
+            {% if current_user.is_authenticated %}
+                <!-- Botón visible -->
+                <a href="#" id="uploadButton" class="btn btn-primary mt-3" style="border-radius: 5px;">
+                    <i data-feather="upload" class="center-button-icon"></i>
+                    Upload from ZIP
+                </a>
+            {% endif %}
             <!-- Formulario oculto -->
             <form id="uploadForm" action="/dataset/upload_zip/{{ dataset.id }}" method="post" enctype="multipart/form-data" style="display: none;">
                 <input type="file" id="zipFileInput" name="zipFile" accept=".zip">
@@ -299,6 +301,12 @@
 
 {% if current_user.is_authenticated %}
 <script>
+    document.getElementById("uploadButton").addEventListener("click", function(event) {
+        event.preventDefault(); // Prevenir el comportamiento por defecto del enlace
+    
+        // Mostrar el mensaje en la consola
+        console.log("Cuadro de selección aparecido");
+    });
     document.getElementById('downloadZipButton').addEventListener('click', function() {
         const repoUrl = document.getElementById('repoUrlInput').value;
         document.getElementById('repoUrlHiddenInput').value = repoUrl;

--- a/app/modules/dataset/tests/test_selenium_upload_from_zip.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_zip.py
@@ -1,0 +1,53 @@
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.common.by import By
+from core.environment.host import get_host_for_selenium_testing
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from core.selenium.common import initialize_driver, close_driver
+
+def wait_for_page_to_load(driver, timeout=4):
+    WebDriverWait(driver, timeout).until(
+        lambda driver: driver.execute_script("return document.readyState") == "complete"
+    )
+    
+SAMPLE_DATASET_ROUTE = "/doi/10.1234/dataset1/"  # Route for Sample Dataset 1
+
+def test_exists_button():
+    driver = initialize_driver()
+    
+    try:
+        host = get_host_for_selenium_testing()
+        # Get the number of models in the dataset
+        
+        # 1. Ir a la página de login
+        # Navigate to the login page
+        driver.get(f"{host}/login")
+        wait_for_page_to_load(driver)
+
+        # Login
+        username_input = driver.find_element(By.NAME, "email")
+        password_input = driver.find_element(By.NAME, "password")
+        username_input.send_keys("user1@example.com")
+        password_input.send_keys("1234")
+        password_input.send_keys(Keys.RETURN)
+        wait_for_page_to_load(driver)
+        
+        # 2. Ir la página de un sataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+        
+        # Obtener el botón de subir archivo
+        upload_button = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.ID, "uploadButton"))
+        )   
+        # Verificar si el botón es visible y habilitado
+        assert (
+            upload_button.is_displayed() and upload_button.is_enabled()
+        ), "El botón no está visible o habilitado"
+
+        # Desplazarse al elemento
+        driver.execute_script("arguments[0].scrollIntoView(true);", upload_button)
+
+        assert driver.find_element(By.ID, "uploadButton"), "El botón de subir archivo no existe"
+    finally:
+        close_driver(driver)

--- a/app/modules/dataset/tests/test_selenium_upload_from_zip.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_zip.py
@@ -5,20 +5,23 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from core.selenium.common import initialize_driver, close_driver
 
+
 def wait_for_page_to_load(driver, timeout=4):
     WebDriverWait(driver, timeout).until(
         lambda driver: driver.execute_script("return document.readyState") == "complete"
     )
-    
+
+
 SAMPLE_DATASET_ROUTE = "/doi/10.1234/dataset1/"  # Route for Sample Dataset 1
+
 
 def test_exists_button():
     driver = initialize_driver()
-    
+
     try:
         host = get_host_for_selenium_testing()
         # Get the number of models in the dataset
-        
+
         # 1. Ir a la página de login
         # Navigate to the login page
         driver.get(f"{host}/login")
@@ -31,15 +34,15 @@ def test_exists_button():
         password_input.send_keys("1234")
         password_input.send_keys(Keys.RETURN)
         wait_for_page_to_load(driver)
-        
+
         # 2. Ir la página de un sataset
         driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
         wait_for_page_to_load(driver)
-        
+
         # Obtener el botón de subir archivo
         upload_button = WebDriverWait(driver, 10).until(
             EC.presence_of_element_located((By.ID, "uploadButton"))
-        )   
+        )
         # Verificar si el botón es visible y habilitado
         assert (
             upload_button.is_displayed() and upload_button.is_enabled()
@@ -48,6 +51,8 @@ def test_exists_button():
         # Desplazarse al elemento
         driver.execute_script("arguments[0].scrollIntoView(true);", upload_button)
 
-        assert driver.find_element(By.ID, "uploadButton"), "El botón de subir archivo no existe"
+        assert driver.find_element(
+            By.ID, "uploadButton"
+        ), "El botón de subir archivo no existe"
     finally:
         close_driver(driver)

--- a/app/modules/dataset/tests/test_selenium_upload_from_zip.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_zip.py
@@ -61,17 +61,19 @@ def test_exists_button():
 
 def test_not_exists_button():
     driver = initialize_driver()
-    
+
     try:
         host = get_host_for_selenium_testing()
         # Ir a la página de un dataset
         driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
         wait_for_page_to_load(driver)
-        
+
         try:
             driver.find_element(By.ID, "uploadButton")
             assert False, "El botón de subir archivo existe"
         except NoSuchElementException:
-            assert True  # El botón no se encontró, lo cual es el comportamiento esperado
+            assert (
+                True  # El botón no se encontró, lo cual es el comportamiento esperado
+            )
     finally:
         close_driver(driver)

--- a/app/modules/dataset/tests/test_selenium_upload_from_zip.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_zip.py
@@ -4,6 +4,7 @@ from core.environment.host import get_host_for_selenium_testing
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from core.selenium.common import initialize_driver, close_driver
+from selenium.common.exceptions import NoSuchElementException
 
 
 def wait_for_page_to_load(driver, timeout=4):
@@ -54,5 +55,23 @@ def test_exists_button():
         assert driver.find_element(
             By.ID, "uploadButton"
         ), "El botón de subir archivo no existe"
+    finally:
+        close_driver(driver)
+
+
+def test_not_exists_button():
+    driver = initialize_driver()
+    
+    try:
+        host = get_host_for_selenium_testing()
+        # Ir a la página de un dataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+        
+        try:
+            driver.find_element(By.ID, "uploadButton")
+            assert False, "El botón de subir archivo existe"
+        except NoSuchElementException:
+            assert True  # El botón no se encontró, lo cual es el comportamiento esperado
     finally:
         close_driver(driver)


### PR DESCRIPTION
Descripción del cambio:
Se han añadido pruebas de selenium para la funcionalidad de subir modelos .uvl desde un zip del sistema

Motivación:
El objetivo principal es como usuario de uvlhub tener la posibilidad de poder subir archivos .uvl a los distintos datasets.

Impacto:
Intencionalmente en blanco

Instrucciones:
Antes de aceptar la pull request, se aconseja probar que corran los tests y que no dan fallos en el codacy. Para facilitar el probar los test, introduce este comando en la consola --> pytest app/modules/dataset/tests/test_selenium_upload_from_zip.py