### PR TITLE
test: Añadir pruebas de Selenium para la carga de datasets desde GitHub

### DIFF
--- a/app/modules/dataset/tests/test_selenium_upload_from_github.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_github.py
@@ -4,7 +4,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
 import shutil
+
 
 SAMPLE_DATASET_ROUTE = "/doi/10.1234/dataset1/"
 
@@ -17,14 +19,15 @@ def wait_for_page_to_load(driver, timeout=10):
 
 def test_access_github_modal():
     driver = initialize_driver()
-
     try:
         host = get_host_for_selenium_testing()
         driver.get(f"{host}/login")
         wait_for_page_to_load(driver)
 
         # 2. Enter the email address and password
-        username_input = driver.find_element(By.NAME, "email")
+        username_input = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.NAME, "email"))
+        )
         password_input = driver.find_element(By.NAME, "password")
         username_input.send_keys("user1@example.com")
         password_input.send_keys("1234")
@@ -39,7 +42,9 @@ def test_access_github_modal():
         driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
 
         # 5. Localizar el formulario y el botón dentro del formulario
-        download_zip_form = driver.find_element(By.ID, "downloadZipForm")
+        download_zip_form = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.ID, "downloadZipForm"))
+        )
         repo_url_input = driver.find_element(By.ID, "repoUrlInput")
         download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
 
@@ -47,15 +52,20 @@ def test_access_github_modal():
         repo_url_input.send_keys("https://github.com/rafpulcif/uvlhub.git")
 
         # 7. Hacer clic en el botón "Upload from Github"
-        download_zip_button.click()
+        try:
+            WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.ID, "downloadZipButton"))
+            ).click()
+        except ElementClickInterceptedException:
+            driver.execute_script("arguments[0].scrollIntoView(true);", download_zip_button)
+            download_zip_button.click()
 
         # 8. Verificar que el modal se muestra correctamente
         github_modal = WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.ID, "githubModal"))
         )
-        assert (
-            github_modal.is_displayed()
-        ), "El modal de GitHub no se mostró correctamente."
+        assert github_modal.is_displayed(), "El modal de GitHub no se mostró correctamente."
+
         shutil.rmtree("uploads/temp/")
     finally:
         close_driver(driver)
@@ -63,14 +73,15 @@ def test_access_github_modal():
 
 def test_invalid_github_url():
     driver = initialize_driver()
-
     try:
         host = get_host_for_selenium_testing()
         driver.get(f"{host}/login")
         wait_for_page_to_load(driver)
 
         # 2. Enter the email address and password
-        username_input = driver.find_element(By.NAME, "email")
+        username_input = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.NAME, "email"))
+        )
         password_input = driver.find_element(By.NAME, "password")
         username_input.send_keys("user1@example.com")
         password_input.send_keys("1234")
@@ -85,7 +96,9 @@ def test_invalid_github_url():
         driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
 
         # 5. Localizar el formulario y el botón dentro del formulario
-        download_zip_form = driver.find_element(By.ID, "downloadZipForm")
+        download_zip_form = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.ID, "downloadZipForm"))
+        )
         repo_url_input = driver.find_element(By.ID, "repoUrlInput")
         download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
 
@@ -95,8 +108,76 @@ def test_invalid_github_url():
         # 7. Hacer clic en el botón "Upload from Github"
         try:
             download_zip_button.click()
-        except:
+        except ElementClickInterceptedException:
             assert True
+        else:
+            assert False, "No se lanzó ninguna excepción al hacer clic en el botón."
+    finally:
+        close_driver(driver)
 
+
+def test_input_exists():
+    driver = initialize_driver()
+    try:
+        host = get_host_for_selenium_testing()
+        driver.get(f"{host}")
+        wait_for_page_to_load(driver)
+
+        # 1. Ir a inicio de sesión
+        driver.get(f"{host}/login")
+        wait_for_page_to_load(driver)
+
+        # 2. Enter the email address and password
+        username_input = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.NAME, "email"))
+        )
+        password_input = driver.find_element(By.NAME, "password")
+        username_input.send_keys("user1@example.com")
+        password_input.send_keys("1234")
+        password_input.send_keys(Keys.RETURN)
+        wait_for_page_to_load(driver)
+
+        # 3. Página del dataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+
+        # 4. Hacer scroll al final de la página
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+
+        # 5. Localizar el formulario y el botón dentro del formulario
+        download_zip_form = WebDriverWait(driver, 10).until(
+            EC.presence_of_element_located((By.ID, "downloadZipForm"))
+        )
+        download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
+
+        # 6. Asertar que el botón existe y el form
+        assert download_zip_form is not None
+        assert download_zip_button is not None
+    finally:
+        close_driver(driver)
+
+
+def test_input_not_exists():
+    driver = initialize_driver()
+    try:
+        host = get_host_for_selenium_testing()
+        driver.get(f"{host}")
+        wait_for_page_to_load(driver)
+
+        # 1. Ir a la página del dataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+
+        # 2. Hacer scroll al final de la página
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+
+        # 3. Verificar que el formulario y el botón no existen
+        try:
+            WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.ID, "downloadZipForm"))
+            )
+            assert False, "El formulario no debería existir, pero se encontró."
+        except TimeoutException:
+            assert True
     finally:
         close_driver(driver)

--- a/app/modules/dataset/tests/test_selenium_upload_from_github.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_github.py
@@ -8,6 +8,7 @@ import shutil
 
 SAMPLE_DATASET_ROUTE = "/doi/10.1234/dataset1/"
 
+
 def wait_for_page_to_load(driver, timeout=10):
     WebDriverWait(driver, timeout).until(
         lambda driver: driver.execute_script("return document.readyState") == "complete"
@@ -16,12 +17,12 @@ def wait_for_page_to_load(driver, timeout=10):
 
 def test_access_github_modal():
     driver = initialize_driver()
-    
+
     try:
         host = get_host_for_selenium_testing()
         driver.get(f"{host}/login")
         wait_for_page_to_load(driver)
-        
+
         # 2. Enter the email address and password
         username_input = driver.find_element(By.NAME, "email")
         password_input = driver.find_element(By.NAME, "password")
@@ -29,42 +30,45 @@ def test_access_github_modal():
         password_input.send_keys("1234")
         password_input.send_keys(Keys.RETURN)
         wait_for_page_to_load(driver)
-        
+
         # 3. Página del dataset
         driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
         wait_for_page_to_load(driver)
-        
+
         # 4. Hacer scroll al final de la página
         driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-        
+
         # 5. Localizar el formulario y el botón dentro del formulario
         download_zip_form = driver.find_element(By.ID, "downloadZipForm")
         repo_url_input = driver.find_element(By.ID, "repoUrlInput")
         download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
-        
+
         # 6. Llenar el campo de URL del repositorio
         repo_url_input.send_keys("https://github.com/rafpulcif/uvlhub.git")
-        
+
         # 7. Hacer clic en el botón "Upload from Github"
         download_zip_button.click()
-        
+
         # 8. Verificar que el modal se muestra correctamente
         github_modal = WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.ID, "githubModal"))
         )
-        assert github_modal.is_displayed(), "El modal de GitHub no se mostró correctamente."
+        assert (
+            github_modal.is_displayed()
+        ), "El modal de GitHub no se mostró correctamente."
         shutil.rmtree("uploads/temp/")
     finally:
         close_driver(driver)
 
+
 def test_invalid_github_url():
     driver = initialize_driver()
-    
+
     try:
         host = get_host_for_selenium_testing()
         driver.get(f"{host}/login")
         wait_for_page_to_load(driver)
-        
+
         # 2. Enter the email address and password
         username_input = driver.find_element(By.NAME, "email")
         password_input = driver.find_element(By.NAME, "password")
@@ -72,27 +76,27 @@ def test_invalid_github_url():
         password_input.send_keys("1234")
         password_input.send_keys(Keys.RETURN)
         wait_for_page_to_load(driver)
-        
+
         # 3. Página del dataset
         driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
         wait_for_page_to_load(driver)
-        
+
         # 4. Hacer scroll al final de la página
         driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-        
+
         # 5. Localizar el formulario y el botón dentro del formulario
         download_zip_form = driver.find_element(By.ID, "downloadZipForm")
         repo_url_input = driver.find_element(By.ID, "repoUrlInput")
         download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
-        
+
         # 6. Llenar el campo de URL del repositorio con una URL no válida
         repo_url_input.send_keys("https://github.com/rafpulcif/uvlhub")
-        
+
         # 7. Hacer clic en el botón "Upload from Github"
         try:
             download_zip_button.click()
         except:
             assert True
-    
+
     finally:
         close_driver(driver)

--- a/app/modules/dataset/tests/test_selenium_upload_from_github.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_github.py
@@ -4,7 +4,10 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
-from selenium.common.exceptions import ElementClickInterceptedException, TimeoutException
+from selenium.common.exceptions import (
+    ElementClickInterceptedException,
+    TimeoutException,
+)
 import shutil
 
 
@@ -57,14 +60,18 @@ def test_access_github_modal():
                 EC.element_to_be_clickable((By.ID, "downloadZipButton"))
             ).click()
         except ElementClickInterceptedException:
-            driver.execute_script("arguments[0].scrollIntoView(true);", download_zip_button)
+            driver.execute_script(
+                "arguments[0].scrollIntoView(true);", download_zip_button
+            )
             download_zip_button.click()
 
         # 8. Verificar que el modal se muestra correctamente
         github_modal = WebDriverWait(driver, 10).until(
             EC.visibility_of_element_located((By.ID, "githubModal"))
         )
-        assert github_modal.is_displayed(), "El modal de GitHub no se mostró correctamente."
+        assert (
+            github_modal.is_displayed()
+        ), "El modal de GitHub no se mostró correctamente."
 
         shutil.rmtree("uploads/temp/")
     finally:

--- a/app/modules/dataset/tests/test_selenium_upload_from_github.py
+++ b/app/modules/dataset/tests/test_selenium_upload_from_github.py
@@ -1,0 +1,98 @@
+from core.environment.host import get_host_for_selenium_testing
+from core.selenium.common import close_driver, initialize_driver
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+import shutil
+
+SAMPLE_DATASET_ROUTE = "/doi/10.1234/dataset1/"
+
+def wait_for_page_to_load(driver, timeout=10):
+    WebDriverWait(driver, timeout).until(
+        lambda driver: driver.execute_script("return document.readyState") == "complete"
+    )
+
+
+def test_access_github_modal():
+    driver = initialize_driver()
+    
+    try:
+        host = get_host_for_selenium_testing()
+        driver.get(f"{host}/login")
+        wait_for_page_to_load(driver)
+        
+        # 2. Enter the email address and password
+        username_input = driver.find_element(By.NAME, "email")
+        password_input = driver.find_element(By.NAME, "password")
+        username_input.send_keys("user1@example.com")
+        password_input.send_keys("1234")
+        password_input.send_keys(Keys.RETURN)
+        wait_for_page_to_load(driver)
+        
+        # 3. Página del dataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+        
+        # 4. Hacer scroll al final de la página
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        
+        # 5. Localizar el formulario y el botón dentro del formulario
+        download_zip_form = driver.find_element(By.ID, "downloadZipForm")
+        repo_url_input = driver.find_element(By.ID, "repoUrlInput")
+        download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
+        
+        # 6. Llenar el campo de URL del repositorio
+        repo_url_input.send_keys("https://github.com/rafpulcif/uvlhub.git")
+        
+        # 7. Hacer clic en el botón "Upload from Github"
+        download_zip_button.click()
+        
+        # 8. Verificar que el modal se muestra correctamente
+        github_modal = WebDriverWait(driver, 10).until(
+            EC.visibility_of_element_located((By.ID, "githubModal"))
+        )
+        assert github_modal.is_displayed(), "El modal de GitHub no se mostró correctamente."
+        shutil.rmtree("uploads/temp/")
+    finally:
+        close_driver(driver)
+
+def test_invalid_github_url():
+    driver = initialize_driver()
+    
+    try:
+        host = get_host_for_selenium_testing()
+        driver.get(f"{host}/login")
+        wait_for_page_to_load(driver)
+        
+        # 2. Enter the email address and password
+        username_input = driver.find_element(By.NAME, "email")
+        password_input = driver.find_element(By.NAME, "password")
+        username_input.send_keys("user1@example.com")
+        password_input.send_keys("1234")
+        password_input.send_keys(Keys.RETURN)
+        wait_for_page_to_load(driver)
+        
+        # 3. Página del dataset
+        driver.get(f"{host}{SAMPLE_DATASET_ROUTE}")
+        wait_for_page_to_load(driver)
+        
+        # 4. Hacer scroll al final de la página
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        
+        # 5. Localizar el formulario y el botón dentro del formulario
+        download_zip_form = driver.find_element(By.ID, "downloadZipForm")
+        repo_url_input = driver.find_element(By.ID, "repoUrlInput")
+        download_zip_button = download_zip_form.find_element(By.ID, "downloadZipButton")
+        
+        # 6. Llenar el campo de URL del repositorio con una URL no válida
+        repo_url_input.send_keys("https://github.com/rafpulcif/uvlhub")
+        
+        # 7. Hacer clic en el botón "Upload from Github"
+        try:
+            download_zip_button.click()
+        except:
+            assert True
+    
+    finally:
+        close_driver(driver)


### PR DESCRIPTION
Descripción del cambio:
Se han añadido pruebas de selenium para la funcionalidad de subir modelos .uvl desde un repositorio de githuv que contenga archivos .uvl

Motivación:
El objetivo principal es como usuario de uvlhub tener la posibilidad de poder subir archivos .uvl a los distintos datasets.

Impacto:
Intencionalmente en blanco

Instrucciones:
Antes de aceptar la pull request, se aconseja probar que corran los tests y que no dan fallos en el codacy. Para facilitar el probar los test, introduce este comando en la consola --> pytest app/modules/dataset/tests/test_selenium_upload_from_github.py