### PR TITLE
feat: Nuevo playbook de tests en Vagrant

### DIFF
--- a/vagrant/00_main.yml
+++ b/vagrant/00_main.yml
@@ -5,3 +5,5 @@
 - import_playbook: 04_install_dependencies.yml
 - import_playbook: 05_run_app.yml
 - import_playbook: 06_utilities.yml
+- import_playbook: 07_monitoring.yml
+- import_playbook: 08_tests.yml

--- a/vagrant/08_tests.yml
+++ b/vagrant/08_tests.yml
@@ -1,0 +1,40 @@
+---
+- hosts: all
+  become: true
+
+  vars:
+    common_environment:
+      FLASK_APP_NAME: "{{ flask_app_name }}"
+      FLASK_ENV: "{{ flask_env }}"
+      DOMAIN: "{{ domain }}"
+      MARIADB_HOSTNAME: "{{ mariadb_hostname }}"
+      MARIADB_PORT: "{{ mariadb_port }}"
+      MARIADB_DATABASE: "{{ mariadb_database }}"
+      MARIADB_TEST_DATABASE: "{{ mariadb_test_database }}"
+      MARIADB_USER: "{{ mariadb_user }}"
+      MARIADB_PASSWORD: "{{ mariadb_password }}"
+      MARIADB_ROOT_PASSWORD: "{{ mariadb_root_password }}"
+      WORKING_DIR: "{{ working_dir }}"
+
+  tasks:
+    - name: Ejecutar tests unitarios
+      shell: |
+        source {{ working_dir }}/venv/bin/activate
+        rosemary test
+      args:
+        executable: /bin/bash
+      environment: "{{ common_environment }}"
+
+    - name: Instalar Locust
+      pip:
+        name: locust
+        state: present
+        virtualenv: "{{ working_dir }}/venv"
+
+    - name: Ejecutar pruebas de carga
+      shell: |
+        source {{ working_dir }}/venv/bin/activate
+        locust -f {{ working_dir }}core/bootstraps/locustfile_bootstrap.py --headless -u 100 -r 10 --run-time 10s --host http://localhost:5000 --csv={{ working_dir }}locustresults/locust || true
+      args:
+        executable: /bin/bash
+      environment: "{{ common_environment }}"


### PR DESCRIPTION
Descripción del cambio:
Se ha añadido un nuevo playbook a Vagrant. Este playbook ejecuta los tests unitarios y los tests de carga cuando se levanta la máquina virtual

Motivación:
Completar el aprovisionamiento de Vagrant

Impacto:
Mínimo

Instrucciones:
Comprobar que no se rompe el desplegue de Vagrant
