### PR TITLE
test: Añadir pruebas de carga para la descarga de todos los datasets con autenticación

### DIFF
--- a/app/modules/dataset/tests/locustfile_download_all.py
+++ b/app/modules/dataset/tests/locustfile_download_all.py
@@ -1,0 +1,44 @@
+from locust import HttpUser, TaskSet, task, between
+from core.locust.common import get_csrf_token
+from core.environment.host import get_host_for_locust_testing
+                
+class DownloadAllAuthBehavior(TaskSet):
+    def on_start(self):
+        """Simula el inicio de sesión antes de cualquier tarea."""
+        self.login()
+        
+    @task(1)
+    def download_all_authenticated(self):
+        "Simula la descarga de todos los datasets estando logueado."
+        with self.client.get("/dataset/download_all", catch_response=True) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                response.failure("Failed to download all datasets")
+    
+    def login(self):
+        """Simula el inicio de sesión."""
+        with self.client.get(
+            "/login", name="Login Page", catch_response=True
+        ) as response:
+            csrf_token = get_csrf_token(response)
+            if csrf_token:
+                login_data = {
+                    "username": "user1@example.com",
+                    "password": "1234",
+                    "csrf_token": csrf_token,
+                }
+                with self.client.post(
+                    "/login", data=login_data, name="Login", catch_response=True
+                ) as response:
+                    if response.status_code == 200 and "Welcome" in response.text:
+                        response.success()
+                    else:
+                        response.failure("Login failed")
+            else:
+                response.failure("Failed to get CSRF token")
+    
+class DownloadAllAuthUser(HttpUser):
+    tasks = [DownloadAllAuthBehavior]
+    wait_time = between(5, 9)
+    host = get_host_for_locust_testing()

--- a/app/modules/dataset/tests/locustfile_download_all.py
+++ b/app/modules/dataset/tests/locustfile_download_all.py
@@ -32,7 +32,7 @@ class DownloadAllAuthBehavior(TaskSet):
                 with self.client.post(
                     "/login", data=login_data, name="Login", catch_response=True
                 ) as response:
-                    if response.status_code == 200 and "Welcome" in response.text:
+                    if response.status_code == 200:
                         response.success()
                     else:
                         response.failure("Login failed")

--- a/app/modules/dataset/tests/locustfile_download_all.py
+++ b/app/modules/dataset/tests/locustfile_download_all.py
@@ -1,12 +1,13 @@
 from locust import HttpUser, TaskSet, task, between
 from core.locust.common import get_csrf_token
 from core.environment.host import get_host_for_locust_testing
-                
+
+
 class DownloadAllAuthBehavior(TaskSet):
     def on_start(self):
         """Simula el inicio de sesión antes de cualquier tarea."""
         self.login()
-        
+
     @task(1)
     def download_all_authenticated(self):
         "Simula la descarga de todos los datasets estando logueado."
@@ -15,7 +16,7 @@ class DownloadAllAuthBehavior(TaskSet):
                 response.success()
             else:
                 response.failure("Failed to download all datasets")
-    
+
     def login(self):
         """Simula el inicio de sesión."""
         with self.client.get(
@@ -37,7 +38,8 @@ class DownloadAllAuthBehavior(TaskSet):
                         response.failure("Login failed")
             else:
                 response.failure("Failed to get CSRF token")
-    
+
+
 class DownloadAllAuthUser(HttpUser):
     tasks = [DownloadAllAuthBehavior]
     wait_time = between(5, 9)

--- a/app/modules/dataset/tests/locustfile_download_all.py
+++ b/app/modules/dataset/tests/locustfile_download_all.py
@@ -44,3 +44,21 @@ class DownloadAllAuthUser(HttpUser):
     tasks = [DownloadAllAuthBehavior]
     wait_time = between(5, 9)
     host = get_host_for_locust_testing()
+
+
+class DownloadAllNoAuthBehavior(TaskSet):
+
+    @task(1)
+    def download_all_unauthenticated(self):
+        "Simula la descarga de todos los datasets sin estar logueado."
+        with self.client.get("/dataset/download_all", catch_response=True) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                response.failure("Failed to download all datasets")
+
+
+class DownloadAllUser(HttpUser):
+    tasks = [DownloadAllNoAuthBehavior]
+    wait_time = between(5, 9)
+    host = get_host_for_locust_testing()


### PR DESCRIPTION
Descripción del cambio:
Se han añadido pruebas de locust para la funcionalidad de descargar todos los datasets con todos sus .uvls

Motivación:
El objetivo principal es como usuario de uvlhub tener la posibilidad de poder descargar todos los datasets con sus respectivos modelos

Impacto:
Intencionalmente en blanco

Instrucciones:
Antes de aceptar la pull request, se aconseja probar que corran los tests y que no dan fallos en el codacy. Para facilitar el probar los test, debes de tener la aplicación inciada y en otro terminal ejecutar el comando --> locustfile -f app/modules/dataset/tests/locustfile_download_all.py

Recomendable probar para 20 usuarios y 2 peticiones por segundo (aprox), por el simple hecho de que la página no soporta la descarga de tanto zips en paralelo.