### PR TITLE
test: Agregar pruebas unitarias para la descarga de repositorios desde github

### DIFF
--- a/app/modules/dataset/tests/test_unit_upload_from_github.py
+++ b/app/modules/dataset/tests/test_unit_upload_from_github.py
@@ -95,5 +95,7 @@ def test_upload_github_files_with_files(test_client, setup_database):
     )
 
     # Verificar respuesta
-    assert response.status_code == 200, "Debería manejar correctamente la solicitud con archivos seleccionados"
+    assert (
+        response.status_code == 200
+    ), "Debería manejar correctamente la solicitud con archivos seleccionados"
     logout(test_client)

--- a/app/modules/dataset/tests/test_unit_upload_from_github.py
+++ b/app/modules/dataset/tests/test_unit_upload_from_github.py
@@ -1,0 +1,67 @@
+from app.modules.conftest import login, logout
+from app import db
+import pytest
+from app.modules.auth.models import User
+from app.modules.dataset.models import (
+    DSMetaData,
+    DatasetStatus,
+    PublicationType,
+    DataSet,
+)
+
+@pytest.fixture(scope="module")
+def test_client(test_client):
+    with test_client.application.app_context():
+        db.create_all()  # Crear todas las tablas necesarias para las pruebas
+    yield test_client
+    with test_client.application.app_context():
+        db.session.remove()
+        db.drop_all() 
+
+@pytest.fixture(scope="function")
+def setup_database(test_client):
+    # Crear usuario y dataset para pruebas
+    user_test = User(email="user101@example.com", password="test1234")
+    db.session.add(user_test)
+    db.session.commit()
+    
+    dataset_test = DataSet(
+        user_id=user_test.id,
+        ds_meta_data=DSMetaData(
+            title="Test Dataset",
+            description="Test Description",
+            publication_type=PublicationType.JOURNAL_ARTICLE,
+            dataset_status=DatasetStatus.UNSTAGED,
+        ),
+    )
+    db.session.add(dataset_test)
+    db.session.commit()
+
+    yield {"user": user_test, "dataset": dataset_test}
+
+    # Cleanup después de las pruebas
+    db.session.delete(dataset_test)
+    db.session.delete(user_test)
+    db.session.commit()
+
+def test_download_repo_zip_valid(test_client, setup_database):
+    user = setup_database["user"]
+    login_response = login(test_client, user.email, user.password)
+    assert (
+        login_response.status_code == 200
+    ), f"Login was unsuccessful: {login_response.data}"
+
+    # URL válida pero sin garantizar que la descarga funcione
+    repo_url = "https://github.com/user/repo.git"
+    response = test_client.post(
+        "/dataset/download_repo_zip",
+        data={"repo_url": repo_url},
+        content_type="application/x-www-form-urlencoded",
+        follow_redirects=True,
+    )
+
+    # Verificar respuesta
+    assert response.status_code == 200, "La solicitud debería tener una respuesta válida"
+    if response.status_code == 400:
+        assert "error" in response.json, "Debe existir un mensaje de error en la respuesta"
+    logout(test_client)

--- a/app/modules/dataset/tests/test_unit_upload_from_github.py
+++ b/app/modules/dataset/tests/test_unit_upload_from_github.py
@@ -72,3 +72,28 @@ def test_download_repo_zip_valid(test_client, setup_database):
             "error" in response.json
         ), "Debe existir un mensaje de error en la respuesta"
     logout(test_client)
+
+
+def test_upload_github_files_with_files(test_client, setup_database):
+    user = setup_database["user"]
+    dataset = setup_database["dataset"]
+    login_response = login(test_client, user.email, user.password)
+    assert (
+        login_response.status_code == 200
+    ), f"Login was unsuccessful: {login_response.data}"
+
+    # Simular archivos seleccionados
+    selected_files = ["/path/to/file1.uvl", "/path/to/file2.uvl"]
+    response = test_client.post(
+        "/dataset/upload_github_files",
+        data={
+            "dataset_id": dataset.id,
+            "files": selected_files,
+        },
+        content_type="application/x-www-form-urlencoded",
+        follow_redirects=True,
+    )
+
+    # Verificar respuesta
+    assert response.status_code == 200, "Debería manejar correctamente la solicitud con archivos seleccionados"
+    logout(test_client)

--- a/app/modules/dataset/tests/test_unit_upload_from_github.py
+++ b/app/modules/dataset/tests/test_unit_upload_from_github.py
@@ -9,6 +9,7 @@ from app.modules.dataset.models import (
     DataSet,
 )
 
+
 @pytest.fixture(scope="module")
 def test_client(test_client):
     with test_client.application.app_context():
@@ -16,7 +17,8 @@ def test_client(test_client):
     yield test_client
     with test_client.application.app_context():
         db.session.remove()
-        db.drop_all() 
+        db.drop_all()
+
 
 @pytest.fixture(scope="function")
 def setup_database(test_client):
@@ -24,7 +26,7 @@ def setup_database(test_client):
     user_test = User(email="user101@example.com", password="test1234")
     db.session.add(user_test)
     db.session.commit()
-    
+
     dataset_test = DataSet(
         user_id=user_test.id,
         ds_meta_data=DSMetaData(
@@ -44,6 +46,7 @@ def setup_database(test_client):
     db.session.delete(user_test)
     db.session.commit()
 
+
 def test_download_repo_zip_valid(test_client, setup_database):
     user = setup_database["user"]
     login_response = login(test_client, user.email, user.password)
@@ -61,7 +64,11 @@ def test_download_repo_zip_valid(test_client, setup_database):
     )
 
     # Verificar respuesta
-    assert response.status_code == 200, "La solicitud debería tener una respuesta válida"
+    assert (
+        response.status_code == 200
+    ), "La solicitud debería tener una respuesta válida"
     if response.status_code == 400:
-        assert "error" in response.json, "Debe existir un mensaje de error en la respuesta"
+        assert (
+            "error" in response.json
+        ), "Debe existir un mensaje de error en la respuesta"
     logout(test_client)


### PR DESCRIPTION
**Descripción del cambio**:
Se han añadido pruebas de pyests para la funcionalidad de subida desde github

**Motivación**:
El objetivo principal es como usuario de uvlhub tener la posibilidad de poder subir modelos a cualquier datasets desde un repo sitorio de github

**Impacto**:
Intencionalmente en blanco

**Instrucciones**:
Antes de aceptar la pull request, se aconseja probar que corran los tests y que no dan fallos en el codacy. Para facilitar el probar los test, debes de tener la aplicación inciada y en otro terminal ejecutar el comando --> pytest app/modules/dataset/tests/test_unit_upload_from_github.py