### PR TITLE
Casos erróneos en la subida de archivos UVL para test de rendimiento

### DIFF
--- a/app/modules/flamapy/tests/locustfile.py
+++ b/app/modules/flamapy/tests/locustfile.py
@@ -63,8 +63,13 @@ constraints
                 # Procesar el cuerpo de la respuesta como JSON
                 json_data = response.json()
                 if "errors" not in json_data or len(json_data["errors"]) == 0:
-                    print("❌ Validation failed, but no error details provided in response.")
-                elif json_data["errors"][0] != "The UVL file is empty and cannot be processed.":
+                    print(
+                        "❌ Validation failed, but no error details provided in response."
+                    )
+                elif (
+                    json_data["errors"][0]
+                    != "The UVL file is empty and cannot be processed."
+                ):
                     print(f"❌ Unexpected error message: {json_data['errors'][0]}")
                 else:
                     print("✅ Validation of empty UVL returned expected error.")

--- a/app/modules/flamapy/tests/locustfile.py
+++ b/app/modules/flamapy/tests/locustfile.py
@@ -40,6 +40,60 @@ constraints
         if response.status_code != 200:
             print(f"Validation of valid UVL failed: {response.status_code}")
 
+    @task
+    def validate_empty_uvl(self):
+        """
+        Envía un UVL vacío al endpoint y verifica la respuesta.
+        """
+        empty_uvl_content = ""
+
+        # Simular la subida de un archivo vacío
+        files = {
+            "file": ("empty_model.uvl", BytesIO(empty_uvl_content.encode("utf-8")))
+        }
+
+        # Hacer la petición POST al endpoint
+        response = self.client.post("/flamapy/validate_uvl", files=files)
+
+        # Verificar el estado HTTP de la respuesta
+        if response.status_code != 400:
+            print(f"❌ Expected 400 for empty UVL, got: {response.status_code}")
+        else:
+            try:
+                # Procesar el cuerpo de la respuesta como JSON
+                json_data = response.json()
+                if "errors" not in json_data or len(json_data["errors"]) == 0:
+                    print("❌ Validation failed, but no error details provided in response.")
+                elif json_data["errors"][0] != "The UVL file is empty and cannot be processed.":
+                    print(f"❌ Unexpected error message: {json_data['errors'][0]}")
+                else:
+                    print("✅ Validation of empty UVL returned expected error.")
+            except ValueError:
+                print(f"❌ Invalid JSON in response: {response.text}")
+
+    @task
+    def validate_invalid_uvl(self):
+        invalid_uvl_content = """
+        features
+            Root
+
+        constraints:
+        """
+        files = {
+            "file": ("invalid_model.uvl", BytesIO(invalid_uvl_content.encode("utf-8")))
+        }
+        response = self.client.post("/flamapy/validate_uvl", files=files)
+
+        # Verificar que el estado es 400
+        if response.status_code != 400:
+            print(f"Unexpected status code: {response.status_code}")
+        else:
+            json_data = response.json()
+            if "errors" not in json_data or len(json_data["errors"]) == 0:
+                print("Expected errors in response, but none were provided.")
+            else:
+                print("Validation of invalid UVL returned expected errors.")
+
 
 class FlamapyUser(HttpUser):
     tasks = [FlamapyBehavior]


### PR DESCRIPTION
**Descripción clara del cambio**

Se han añadido casos no contemplados previamente en el test de rendimiento de locust a la hora de subir archivos UVL.

**Motivación del cambio**
Durante la revisión final fui consciente de que no se habían añadido estas pruebas y son importantes de cara a ver cómo funcionan los métodos implementados para el WI en cuanto a rendimiento.

**Impacto del cambio**

  A través de este cambio se consiguen cubrir los escenarios necesarios para probar el rendimiento de la aplicación cuando hay que subir archivos UVL tanto válidos como inválidos